### PR TITLE
Add Kodi Settings to menu Setup enigma

### DIFF
--- a/src/plugin/plugin.py
+++ b/src/plugin/plugin.py
@@ -492,8 +492,8 @@ class KodiVideoPlayer(InfoBarBase, InfoBarShowHide, SubsSupportStatus, SubsSuppo
                 title = re.sub(r"\[.*?\]","",str(title), flags=re.DOTALL)
             except:
                 pass
- 
-        
+
+
         self.title_ref = title
 
         # set start position if provided
@@ -1093,7 +1093,7 @@ class KodiLauncher(Screen):
         RCUnlock()
         setaudio.switch()
         self.endTimer1.start(1000, True)
-        
+
     def end1(self):
         self.endTimer1.stop()
         setresolution.switch()
@@ -1189,8 +1189,8 @@ def startLauncher(session, **kwargs):
         KODI_LAUNCHER = session.open(KodiLauncher)
 
 def startMenuLauncher(menuid, **kwargs):
-    if menuid == "mainmenu":
-        return [("Kodi", startLauncher, "kodi", 1)]
+    if menuid == "setup":
+        return [(_("Kodi Settings"), startSetup, "kodi", 1)]
     return []
 
 class KodiExtSetup(Setup):
@@ -1216,9 +1216,8 @@ def Plugins(**kwargs):
         PluginDescriptor("Kodi", PluginDescriptor.WHERE_AUTOSTART, _("Kodi Launcher"), fnc=autoStart),
         PluginDescriptor("Kodi", PluginDescriptor.WHERE_PLUGINMENU, _("Kodi Settings"), icon=kodiext, fnc=startSetup)
       ]
-    if config.kodi.addToMainMenu.value:
-        l.append(PluginDescriptor(name="Kodi", where=PluginDescriptor.WHERE_MENU, fnc=startMenuLauncher))
     if config.kodi.addToExtensionMenu.value:
         l.append(PluginDescriptor(name="Kodi", where=PluginDescriptor.WHERE_EXTENSIONSMENU, icon=kodiext, fnc=startLauncher))
+    l.append(PluginDescriptor(name="Kodi", where=PluginDescriptor.WHERE_MENU, fnc=startMenuLauncher))
     return l
 

--- a/src/plugin/setup.xml
+++ b/src/plugin/setup.xml
@@ -1,6 +1,6 @@
 <setupxml>
 	<setup key="Kodi" title="Kodi Settings" allowDefault="1">
-		<item level="0" text="Add Kodi to Main Menu" description="Add Kodi to the Main Menu list of options.">config.kodi.addToMainMenu</item>
+		<!--item level="0" text="Add Kodi to Main Menu" description="Add Kodi to the Main Menu list of options.">config.kodi.addToMainMenu</item-->
 		<item level="0" text="Add Kodi to Extensions Menu" description="Add Kodi to the Extensions Menu list of options.">config.kodi.addToExtensionMenu</item>
 		<item level="0" text="Start Kodi Standalone" description="Select 'Yes' to start Kodi standalone. Warning!! This will stop enigma including all functions.">config.kodi.standalone</item>
 		<item level="0" text="Default Player" description="Select Default Player for Kodi">config.kodi.player</item>


### PR DESCRIPTION
OpenSPA always has the "Kodi" start launcher in its main menu if the plugin is installed.

What's not available in Enigma is the settings menu. "Kodi Settings" is added to the menu "setup".